### PR TITLE
Support uploading media

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	implementation 'com.squareup.okio:okio:3.5.0'
 	implementation 'org.jsoup:jsoup:1.16.1'
 	implementation 'net.peanuuutz:tomlkt:0.2.0'
+	implementation 'org.apache.tika:tika-core:2.9.0'
 
 	testImplementation 'junit:junit:4.13.2'
 	testImplementation 'org.jetbrains.kotlin:kotlin-test'

--- a/src/main/kotlin/com/jakewharton/dumbo/mediaDb.kt
+++ b/src/main/kotlin/com/jakewharton/dumbo/mediaDb.kt
@@ -1,0 +1,94 @@
+package com.jakewharton.dumbo
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.div
+import kotlin.io.path.exists
+import kotlin.io.path.notExists
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okio.BufferedSink
+import okio.sink
+import okio.source
+import org.apache.tika.Tika
+import retrofit2.HttpException
+
+class MediaDb(
+	directory: Path,
+	private val mastodonApi: MastodonApi,
+	private val authentication: String,
+	private val twimgApi: TwimgApi,
+) {
+	private val tika = Tika()
+	private val originalDir = directory / "dumbo-media"
+	private val archiveDir = directory / "data/tweets_media"
+
+	suspend fun uploadMedia(id: String, path: String): String {
+		val filename = "$id-$path"
+		val original = originalDir / filename
+		val archived = archiveDir / filename
+
+		if (original.notExists()) {
+			try {
+				twimgApi.downloadImage(path, "orig").source().use { source ->
+					originalDir.createDirectories()
+					original.sink().use(source::readAll)
+				}
+			} catch (e: HttpException) {
+				if (e.code() != 404) {
+					throw e
+				}
+			}
+		}
+
+		val upload = original.takeIf { it.exists() }
+			?: archived.takeIf { it.exists() }
+			?: throw IllegalStateException("No media available for $id $path")
+
+		val contentType = tika.detect(upload).toMediaType()
+
+		val uploadResponse = mastodonApi.uploadMedia(
+			authorization = authentication,
+			file = MultipartBody.Part.createFormData("file", id, PathRequestBody(upload, contentType)),
+			description = "",
+		)
+		return when (uploadResponse.code()) {
+			200 -> {
+				// Media was small enough to be processed synchronously.
+				uploadResponse.body()!!.id
+			}
+			202 -> {
+				val attachmentId = uploadResponse.body()!!.id
+				// Media was enqueued to be processed. Wait for it to be processed...
+				while (true) {
+					delay(10.seconds)
+					val getResponse = mastodonApi.getMedia(authentication, attachmentId)
+					when (getResponse.code()) {
+						200 -> break
+						206 -> continue
+						else -> throw HttpException(getResponse)
+					}
+				}
+				attachmentId
+			}
+			else -> throw HttpException(uploadResponse)
+		}
+	}
+}
+
+private class PathRequestBody(
+	private val path: Path,
+	private val contentType: MediaType,
+) : RequestBody() {
+	override fun contentType() = contentType
+	override fun contentLength() = Files.size(path)
+
+	override fun writeTo(sink: BufferedSink) {
+		path.source().use(sink::writeAll)
+	}
+}

--- a/src/main/kotlin/com/jakewharton/dumbo/twitterArchive.kt
+++ b/src/main/kotlin/com/jakewharton/dumbo/twitterArchive.kt
@@ -1,5 +1,6 @@
 package com.jakewharton.dumbo
 
+import com.jakewharton.dumbo.Tweet.MediaEntity
 import com.jakewharton.dumbo.Tweet.MentionEntity
 import com.jakewharton.dumbo.Tweet.UrlEntity
 import java.nio.file.Path
@@ -60,6 +61,13 @@ class TwitterArchive(
 							indices = entity.indices,
 						)
 					}
+					this += it.tweet.entities.media.map { entity ->
+						MediaEntity(
+							id = entity.id,
+							filename = entity.media_url.substringAfterLast("/"),
+							indices = entity.indices,
+						)
+					}
 				}
 			)
 		}.sorted()
@@ -104,6 +112,11 @@ data class Tweet(
 	data class MentionEntity(
 		val id: String,
 		val username: String,
+		override val indices: IntRange,
+	) : Entity
+	data class MediaEntity(
+		val id: String,
+		val filename: String,
 		override val indices: IntRange,
 	) : Entity
 }

--- a/src/main/kotlin/com/jakewharton/dumbo/twitterImageApi.kt
+++ b/src/main/kotlin/com/jakewharton/dumbo/twitterImageApi.kt
@@ -1,0 +1,15 @@
+package com.jakewharton.dumbo
+
+import okhttp3.ResponseBody
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Streaming
+
+interface TwimgApi {
+	@Streaming
+	@GET("/media/{filename}:{quality}")
+	suspend fun downloadImage(
+		@Path("filename") filename: String,
+		@Path("quality") quality: String,
+	): ResponseBody
+}

--- a/src/test/kotlin/com/jakewharton/dumbo/MastodonTest.kt
+++ b/src/test/kotlin/com/jakewharton/dumbo/MastodonTest.kt
@@ -199,4 +199,109 @@ class MastodonTest {
 		val actual = Toot.fromTweet(tweet, InMemoryDumboDb(), mapping)
 		assertEquals(expected, actual)
 	}
+
+	@Test fun mediaOnlySingle() {
+		val tweet = Tweet(
+			id = "91268136095068160",
+			createdAt = Instant.parse("2011-07-13T22:09:53Z"),
+			language = "en",
+			text = "http://example.com",
+			entities = listOf(
+				Tweet.MediaEntity(
+					id = "124",
+					filename = "example.png",
+					indices = 0..18,
+				),
+			),
+		)
+		val expected = Toot(
+			text = "",
+			posted = Instant.parse("2011-07-13T22:09:53Z"),
+			language = "en",
+			media = listOf(
+				Toot.Media(
+					id = "124",
+					filename = "example.png",
+				),
+			),
+		)
+		val actual = Toot.fromTweet(tweet, InMemoryDumboDb(), IdentityMapping.Empty)
+		assertEquals(expected, actual)
+	}
+
+	@Test fun mediaOnlyMany() {
+		val tweet = Tweet(
+			id = "91268136095068160",
+			createdAt = Instant.parse("2011-07-13T22:09:53Z"),
+			language = "en",
+			text = "http://example.com http://example.net http://example.org",
+			entities = listOf(
+				Tweet.MediaEntity(
+					id = "124",
+					filename = "example1.png",
+					indices = 0..18,
+				),
+				Tweet.MediaEntity(
+					id = "125",
+					filename = "example2.png",
+					indices = 19..37,
+				),
+				Tweet.MediaEntity(
+					id = "126",
+					filename = "example3.png",
+					indices = 38..56,
+				),
+			),
+		)
+		val expected = Toot(
+			text = "",
+			posted = Instant.parse("2011-07-13T22:09:53Z"),
+			language = "en",
+			media = listOf(
+				Toot.Media(
+					id = "124",
+					filename = "example1.png",
+				),
+				Toot.Media(
+					id = "125",
+					filename = "example2.png",
+				),
+				Toot.Media(
+					id = "126",
+					filename = "example3.png",
+				),
+			),
+		)
+		val actual = Toot.fromTweet(tweet, InMemoryDumboDb(), IdentityMapping.Empty)
+		assertEquals(expected, actual)
+	}
+
+	@Test fun textWithMedia() {
+		val tweet = Tweet(
+			id = "91268136095068160",
+			createdAt = Instant.parse("2011-07-13T22:09:53Z"),
+			language = "en",
+			text = "Some text goes here! http://example.com",
+			entities = listOf(
+				Tweet.MediaEntity(
+					id = "124",
+					filename = "example.png",
+					indices = 21..39,
+				),
+			),
+		)
+		val expected = Toot(
+			text = "Some text goes here!",
+			posted = Instant.parse("2011-07-13T22:09:53Z"),
+			language = "en",
+			media = listOf(
+				Toot.Media(
+					id = "124",
+					filename = "example.png",
+				),
+			),
+		)
+		val actual = Toot.fromTweet(tweet, InMemoryDumboDb(), IdentityMapping.Empty)
+		assertEquals(expected, actual)
+	}
 }


### PR DESCRIPTION
This tries to resolve the original media from Twitter since the ones embedded in the dump are not original size.

Old posts that are missing media will be edited. Currently the only heuristic for matching media is the count.

Closes #7. Closes #19.